### PR TITLE
added support for the cedrus c-pod

### DIFF
--- a/pyxid/pyxid_impl.py
+++ b/pyxid/pyxid_impl.py
@@ -404,6 +404,11 @@ class XidDevice(object):
                     rb_834_keymap)
             else:
                 raise XidError('Unknown RB Device')
+        elif product_id == 4:
+            self._impl = StimTracker(
+                self.con,
+                'Cedrus C-POD')
+
         elif product_id == b'S':
             fw_major = int(self._send_command('_d4', 1))
             fw_minor = int(self._send_command('_d5', 1))


### PR DESCRIPTION
When trying to operate a Cedrus C-POD with pyxid I noticed that the C-POD is not yet support. After adding its product_id in init_device and treating it like a strimtracker I could talk to the hardware.